### PR TITLE
Refactor out some of the constants used into a config module

### DIFF
--- a/src/covid_integration/config/constants.py
+++ b/src/covid_integration/config/constants.py
@@ -1,0 +1,119 @@
+"""
+COVID-19 Data Integration - Configuration Constants
+
+Centralized configuration and constants for the entire project.
+This module contains all hardcoded values, mappings, and configuration
+parameters used across different modules.
+"""
+
+# Data source URLs
+OWID_CSV_URL = "https://raw.githubusercontent.com/owid/covid-19-data/refs/heads/master/public/data/owid-covid-data.csv"
+DISEASE_SH_API_URL = "https://disease.sh/v3/covid-19/countries"
+
+# Country name mapping dictionary to handle mismatches between data sources
+COUNTRY_NAME_MAPPING = {
+    # OWID name -> disease.sh API name
+    "Bosnia and Herzegovina": "Bosnia",
+    "Cape Verde": "Cabo Verde",
+    "Cote d'Ivoire": "Côte d'Ivoire",
+    "Democratic Republic of Congo": "DRC",
+    "East Timor": "Timor-Leste",
+    "Curacao": "Curaçao",
+    "Bonaire Sint Eustatius and Saba": "Caribbean Netherlands",
+    "United States": "USA",
+    "United Kingdom": "UK",
+    "South Korea": "S. Korea",
+    "Czech Republic": "Czechia",
+    "North Macedonia": "Macedonia",
+    "Myanmar": "Burma",
+    "Republic of the Congo": "Congo",
+    "Eswatini": "Swaziland",
+    "Vatican": "Holy See (Vatican City State)",
+    "Brunei": "Brunei Darussalam",
+    "Moldova": "Moldova, Republic of",
+    "Russia": "Russian Federation",
+    "Syria": "Syrian Arab Republic",
+    "Tanzania": "Tanzania, United Republic of",
+    "Turkey": "Turkey",
+    "Venezuela": "Venezuela, Bolivarian Republic of",
+    "Vietnam": "Viet Nam",
+    "Laos": "Lao People's Democratic Republic",
+}
+
+# Countries/regions to exclude (aggregates, non-countries)
+EXCLUDE_REGIONS = {
+    "World",
+    "Africa",
+    "Asia",
+    "Europe",
+    "North America",
+    "South America",
+    "Oceania",
+    "European Union",
+    "High income",
+    "Low income",
+    "Lower middle income",
+    "Upper middle income",
+    "OECD countries",
+    "International",
+    "MS Zaandam",
+    "Diamond Princess",
+}
+
+# Default parameters for analysis
+DEFAULT_TREND_WINDOW_DAYS = 30
+DEFAULT_OUTPUT_DIR = "outputs"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+# Data quality thresholds
+MIN_POPULATION_THRESHOLD = 1000
+MAX_POPULATION_THRESHOLD = 2e9
+LARGE_DATA_GAP_THRESHOLD = 10.0  # percent
+OLD_DATA_THRESHOLD_DAYS = 90
+
+# Visualization constants
+DEFAULT_FIGURE_SIZE = (12, 8)
+DEFAULT_DPI = 300
+DEFAULT_TOP_N_COUNTRIES = 15
+
+# Color palette for consistent styling
+COLORS = {
+    "primary": "#2E86AB",
+    "secondary": "#A23B72",
+    "accent": "#F18F01",
+    "success": "#C73E1D",
+    "warning": "#F4A261",
+    "info": "#264653",
+}
+
+# Column name mappings for consistency
+COLUMN_MAPPINGS = {
+    # Standard column names used throughout the project
+    "country_col": "country_standardized",
+    "date_col": "date",
+    "iso_col": "iso_code",
+    "population_col": "population",
+    "cases_col": "total_cases",
+    "deaths_col": "total_deaths",
+}
+
+# Logging configuration
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+LOG_LEVEL = "INFO"
+
+# File extensions and formats
+SUPPORTED_OUTPUT_FORMATS = [".csv", ".json", ".xlsx"]
+DEFAULT_IMAGE_FORMAT = "png"
+
+# API and data processing limits
+MAX_RETRIES = 3
+BATCH_SIZE = 1000
+MAX_COUNTRIES_FOR_COMPARISON = 10
+
+# Data validation rules
+REQUIRED_OWID_COLUMNS = ["country", "date", "iso_code", "total_cases"]
+REQUIRED_API_COLUMNS = ["country", "cases", "deaths", "population"]
+
+# Cache and performance settings
+ENABLE_CACHING = True
+CACHE_EXPIRY_HOURS = 24

--- a/src/covid_integration/data_cleaner.py
+++ b/src/covid_integration/data_cleaner.py
@@ -12,58 +12,22 @@ from typing import Dict, Tuple
 import numpy as np
 import pandas as pd
 
+# Import centralized constants
+try:
+    # Relative import (when used as module)
+    from .config.constants import (
+        COUNTRY_NAME_MAPPING,
+        EXCLUDE_REGIONS,
+    )
+except ImportError:
+    # Absolute import (when run directly)
+    from covid_integration.config.constants import (
+        COUNTRY_NAME_MAPPING,
+        EXCLUDE_REGIONS,
+    )
+
 # Configure logging
 logger = logging.getLogger(__name__)
-
-# Country name mapping dictionary to handle mismatches between data sources
-COUNTRY_NAME_MAPPING = {
-    # OWID name -> disease.sh API name
-    "Bosnia and Herzegovina": "Bosnia",
-    "Cape Verde": "Cabo Verde",
-    "Cote d'Ivoire": "Côte d'Ivoire",
-    "Democratic Republic of Congo": "DRC",
-    "East Timor": "Timor-Leste",
-    "Curacao": "Curaçao",
-    "Bonaire Sint Eustatius and Saba": "Caribbean Netherlands",
-    "United States": "USA",
-    "United Kingdom": "UK",
-    "South Korea": "S. Korea",
-    "Czech Republic": "Czechia",
-    "North Macedonia": "Macedonia",
-    "Myanmar": "Burma",
-    "Republic of the Congo": "Congo",
-    "Eswatini": "Swaziland",
-    "Vatican": "Holy See (Vatican City State)",
-    "Brunei": "Brunei Darussalam",
-    "Moldova": "Moldova, Republic of",
-    "Russia": "Russian Federation",
-    "Syria": "Syrian Arab Republic",
-    "Tanzania": "Tanzania, United Republic of",
-    "Turkey": "Turkey",
-    "Venezuela": "Venezuela, Bolivarian Republic of",
-    "Vietnam": "Viet Nam",
-    "Laos": "Lao People's Democratic Republic",
-}
-
-# Countries/regions to exclude (aggregates, non-countries)
-EXCLUDE_REGIONS = {
-    "World",
-    "Africa",
-    "Asia",
-    "Europe",
-    "North America",
-    "South America",
-    "Oceania",
-    "European Union",
-    "High income",
-    "Low income",
-    "Lower middle income",
-    "Upper middle income",
-    "OECD countries",
-    "International",
-    "MS Zaandam",
-    "Diamond Princess",
-}
 
 
 def standardize_country_names(df: pd.DataFrame, source: str = "owid") -> pd.DataFrame:

--- a/src/covid_integration/data_loader.py
+++ b/src/covid_integration/data_loader.py
@@ -13,13 +13,20 @@ from typing import Dict, List
 import pandas as pd
 import requests
 
+# Import centralized constants
+try:
+    # Relative import (when used as module)
+    from .config.constants import DISEASE_SH_API_URL, OWID_CSV_URL
+except ImportError:
+    # Absolute import (when run directly)
+    from covid_integration.config.constants import (
+        DISEASE_SH_API_URL,
+        OWID_CSV_URL,
+    )
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
-
-# Data source URLs
-OWID_CSV_URL = "https://raw.githubusercontent.com/owid/covid-19-data/refs/heads/master/public/data/owid-covid-data.csv"  # noqa: E501
-DISEASE_SH_API_URL = "https://disease.sh/v3/covid-19/countries"
 
 
 def load_owid_data(url: str = OWID_CSV_URL) -> pd.DataFrame:

--- a/src/covid_integration/data_merger.py
+++ b/src/covid_integration/data_merger.py
@@ -13,6 +13,14 @@ from typing import Dict, Tuple
 import numpy as np
 import pandas as pd
 
+# Import centralized constants
+try:
+    # Relative import (when used as module)
+    from .config.constants import DEFAULT_TREND_WINDOW_DAYS
+except ImportError:
+    # Absolute import (when run directly)
+    from covid_integration.config.constants import DEFAULT_TREND_WINDOW_DAYS
+
 # Configure logging
 logger = logging.getLogger(__name__)
 
@@ -110,7 +118,9 @@ def align_temporal_data(
         raise ValueError(f"Unsupported alignment strategy: {alignment_strategy}")
 
 
-def calculate_trend_metrics(owid_df: pd.DataFrame, window_days: int = 30) -> pd.DataFrame:
+def calculate_trend_metrics(
+    owid_df: pd.DataFrame, window_days: int = DEFAULT_TREND_WINDOW_DAYS
+) -> pd.DataFrame:
     """
     Calculate trend metrics from historical data for the last N days.
 

--- a/src/covid_integration/visualizer.py
+++ b/src/covid_integration/visualizer.py
@@ -16,6 +16,22 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
+# Import centralized constants
+try:
+    # Relative import (when used as module)
+    from .config.constants import (
+        COLORS,
+        DEFAULT_DPI,
+        DEFAULT_FIGURE_SIZE,
+    )
+except ImportError:
+    # Absolute import (when run directly)
+    from covid_integration.config.constants import (
+        COLORS,
+        DEFAULT_DPI,
+        DEFAULT_FIGURE_SIZE,
+    )
+
 # Configure logging
 logger = logging.getLogger(__name__)
 
@@ -24,22 +40,12 @@ plt.style.use("seaborn-v0_8")
 sns.set_palette("husl")
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-# Custom color palette
-COLORS = {
-    "primary": "#2E86AB",
-    "secondary": "#A23B72",
-    "accent": "#F18F01",
-    "success": "#C73E1D",
-    "warning": "#F4A261",
-    "info": "#264653",
-}
-
 
 def setup_plot_style():
     """Set up consistent styling for all plots."""
     plt.rcParams.update(
         {
-            "figure.figsize": (12, 8),
+            "figure.figsize": DEFAULT_FIGURE_SIZE,
             "font.size": 11,
             "axes.titlesize": 14,
             "axes.labelsize": 12,
@@ -47,7 +53,7 @@ def setup_plot_style():
             "ytick.labelsize": 10,
             "legend.fontsize": 10,
             "figure.titlesize": 16,
-            "savefig.dpi": 300,
+            "savefig.dpi": DEFAULT_DPI,
             "savefig.bbox": "tight",
         }
     )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -16,7 +16,7 @@ import plotly.express as px
 import streamlit as st
 
 # Add src directory to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 from covid_integration.data_cleaner import clean_all_data
 


### PR DESCRIPTION
I performed the following code quality checks:

- [x] Format with black (`poetry run black src/ tests/ streamlit_app.py`)
- [x] Organize imports (`poetry run isort src/ tests/ streamlit_app.py`)
- [x] Linting with flake8 (`poetry run flake8 src/ tests/ streamlit_app.py --max-line-length=100`)
- [x] Verified that tests ran (`poetry run pytest tests/test_integration.py -v`)