### PR TITLE
Fix duplicate logging messages in centralized logging

### DIFF
--- a/src/covid_integration/data_cleaner.py
+++ b/src/covid_integration/data_cleaner.py
@@ -14,17 +14,11 @@ import pandas as pd
 # Import centralized constants and logging
 try:
     # Relative import (when used as module)
-    from .config.constants import (
-        COUNTRY_NAME_MAPPING,
-        EXCLUDE_REGIONS,
-    )
+    from .config.constants import COUNTRY_NAME_MAPPING, EXCLUDE_REGIONS
     from .config.logging_config import get_logger
 except ImportError:
     # Absolute import (when run directly)
-    from covid_integration.config.constants import (
-        COUNTRY_NAME_MAPPING,
-        EXCLUDE_REGIONS,
-    )
+    from covid_integration.config.constants import COUNTRY_NAME_MAPPING, EXCLUDE_REGIONS
     from covid_integration.config.logging_config import get_logger
 
 # Configure logging

--- a/src/covid_integration/visualizer.py
+++ b/src/covid_integration/visualizer.py
@@ -18,19 +18,11 @@ import seaborn as sns
 # Import centralized constants and logging
 try:
     # Relative import (when used as module)
-    from .config.constants import (
-        COLORS,
-        DEFAULT_DPI,
-        DEFAULT_FIGURE_SIZE,
-    )
+    from .config.constants import COLORS, DEFAULT_DPI, DEFAULT_FIGURE_SIZE
     from .config.logging_config import get_logger
 except ImportError:
     # Absolute import (when run directly)
-    from covid_integration.config.constants import (
-        COLORS,
-        DEFAULT_DPI,
-        DEFAULT_FIGURE_SIZE,
-    )
+    from covid_integration.config.constants import COLORS, DEFAULT_DPI, DEFAULT_FIGURE_SIZE
     from covid_integration.config.logging_config import get_logger
 
 # Configure logging


### PR DESCRIPTION
- Simplified logging configuration to use Python's basicConfig
- Added global flag to prevent duplicate configuration
- Removed complex custom handler setup that was causing duplication
- Clean single-line log output while maintaining centralized control